### PR TITLE
Added Samples -> Samples~ command

### DIFF
--- a/ci/move_to_packagebranch.sh
+++ b/ci/move_to_packagebranch.sh
@@ -37,6 +37,8 @@ tar -tf archive.tar
 tar -xf archive.tar --overwrite
 rm archive.tar
 
+mv Samples Samples~
+
 git add -A
 
 echo "Diffs:"


### PR DESCRIPTION
Allows you to maintain a "Samples" folder in the master branch. Samples can be imported via the fancy package manager UI, but the folder needs to be named "Samples~" in the UPM package. Unity treats files with ~ on the end as hidden, so it makes it annoying to work on your samples if you keep that name in the master branch. See https://forum.unity.com/threads/samples-in-packages-manual-setup.623080/

![Image of Yaktocat](https://forum.unity.com/proxy.php?image=https%3A%2F%2Flh6.googleusercontent.com%2FQyPB167AeWTt0mZNETd1GBafjZC_D5q3oMufXSbLhd7UTvnc9SVf2fknXTU438_Hi-7tuG3iuKujwEercerKWEmfF-jMveOvLVYyh7IQ7HKJtlWd3SFnUh9yTcCpZqOP_Fce04aL&hash=6e48b7cf15fe4e05b713ad46afc1144f)
